### PR TITLE
[golangci] Fix deprecation warnings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,14 +1,15 @@
 run:
   timeout: 30m
 output:
-  format: line-number
+  formats:
+  - format: line-number
 linters:
   disable-all: false
   enable:
   - bodyclose
+  - copyloopvar
   - dogsled
   - errcheck
-  - exportloopref
   - gocognit
   - goconst
   - gocritic


### PR DESCRIPTION
```
WARN [config_reader] The configuration option `output.format` is deprecated, please use `output.formats`
WARN The linter 'exportloopref' is deprecated (since v1.60.2) due to: Since Go1.22 (loopvar) this linter is no longer relevant. Replaced by copyloopvar.
```